### PR TITLE
Fix travel_plans_status and convert all status calls to _status

### DIFF
--- a/guests/models.py
+++ b/guests/models.py
@@ -55,7 +55,7 @@ class GuestGroup(MagModel):
         properties here, but it's vital to allow events to control group checklists with granularity.
         """
         if name.endswith('_status'):
-            return self.status(name.split('_')[0])
+            return self.status(name.rsplit('_', 1)[0])
         else:
             return super(GuestGroup, self).__getattr__(name)
 

--- a/guests/templates/checklist/bio_deadline.html
+++ b/guests/templates/checklist/bio_deadline.html
@@ -7,7 +7,7 @@
   <tr>
     <td colspan="3">
       {% block deadline_text %}
-        {% if guest.bio.status %}
+        {% if guest.bio_status %}
           You have already provided us with your bio information, but you can use the link above to update it.
           {% if not guest.bio.uploaded_pic %}
             We encourage you to upload a bio pic (which you have NOT yet done) so that we can

--- a/guests/templates/checklist/charity_deadline.html
+++ b/guests/templates/checklist/charity_deadline.html
@@ -8,7 +8,7 @@
   <tr>
     <td colspan="3">
       {% block deadline_text %}
-        {% if guest.charity.status %}
+        {% if guest.charity_status %}
           You have already indicated your charity preferences, but you may update them using the link above.
         {% else %}
           {{ c.EVENT_NAME }} runs a yearly charity auction, and we need you to tell us whether you can contribute any

--- a/guests/templates/checklist/guest_bio_deadline.html
+++ b/guests/templates/checklist/guest_bio_deadline.html
@@ -1,7 +1,7 @@
 {% extends "checklist/bio_deadline.html" %}
 {% block deadline_headline %}Guest/Group Information{% endblock %}
 {% block deadline_text %}
-{% if guest.bio.status %}
+{% if guest.bio_status %}
   You have already provided us with your bio information, but you can use the link above to update it.
   {% if not guest.bio.uploaded_pic %}
     We encourage you to upload a bio pic (which you have NOT yet done) so that we can

--- a/guests/templates/checklist/info_deadline.html
+++ b/guests/templates/checklist/info_deadline.html
@@ -8,7 +8,7 @@
 <tr>
   <td colspan="3">
   {% block deadline_text %}
-    {% if guest.info.status %}
+    {% if guest.info_status %}
       You have already provided all the information required as part of your agreement.  You may edit your
       information (e.g. if you've discovered that you'll be arriving on a different day or time) using the link above.
     {% else %}

--- a/guests/templates/checklist/panel_deadline.html
+++ b/guests/templates/checklist/panel_deadline.html
@@ -8,7 +8,7 @@
   <tr>
     <td colspan="3">
       {% block deadline_text %}
-        {% if not guest.panel.status %}
+        {% if not guest.panel_status %}
           Please use the above link to let us know whether or not you are interested in also running a panel.
           We cannot accommodate all requests, but we definitely want to hear your ideas!
         {% elif guest.panel.wants_panel %}

--- a/guests/templates/checklist/stage_plot_deadline.html
+++ b/guests/templates/checklist/stage_plot_deadline.html
@@ -21,7 +21,7 @@
   <h2>{% block form_headline %}Stage Layout for {{ guest.group.name }}{% endblock %}</h2>
 
   {% block form_desc %}
-    {% if guest.stage_plot.status %}
+    {% if guest.stage_plot_status %}
       <a href="{{ guest.stage_plot.url }}">Click here to view the stage layouts you uploaded.</a>
       <br/><br/>
       Need to update something?

--- a/guests/templates/guest_admin/band_info.html
+++ b/guests/templates/guest_admin/band_info.html
@@ -32,7 +32,7 @@
       <div class="form-control-static">
         {% if not guest.payment %}
           This band isn't being paid and thus doesn't need a W9 tax form.
-        {% elif guest.taxes.status %}
+        {% elif guest.taxes_status %}
           <a href="{{ guest.taxes.w9_url }}">Click here to view the band's uploaded W9 tax form</a>
         {% else %}
           This band is supposed to be paid, but has not uploaded a W9 tax form yet.


### PR DESCRIPTION
There was a bug in the getattr function that would split the attribute too much, causing travel_plans_status to always return 'N/A' because it ended up checking a nonexistent property. This fixes that, plus changes all the old status calls to use the new functionality.