### PR TITLE
Suppresses the Rock Island promo image on the full /guest_admin/rock_island page

### DIFF
--- a/guests/templates/guest_admin/rock_island.html
+++ b/guests/templates/guest_admin/rock_island.html
@@ -111,7 +111,7 @@
           </h2>
           {{ guest_merch_contact_info(guest_merch) }}
         </div>
-        {{ guests_macros.inventory_table_with_err('panel-body') }}
+        {{ guests_macros.inventory_table_with_err('panel-body', suppress_preview=True) }}
       </div>
     {%- endfor %}
   {% elif guest_groups|length > 0 %}
@@ -126,7 +126,7 @@
       <div class="clearfix"></div>
     </h1>
     {{ guest_merch_contact_info(guest_merch) }}
-    {{ guests_macros.inventory_table_with_err() }}
+    {{ guests_macros.inventory_table_with_err(suppress_preview=False) }}
   {% else %}
     <h1>Rock Island</h1>
     <p class="text-danger">No groups have signed up for Rock Island yet.</p>

--- a/guests/templates/guests_common.html
+++ b/guests/templates/guests_common.html
@@ -97,11 +97,6 @@
   width: 100%;
 }
 
-.inventory-item .inventory-file-image img {
-  display: block;
-  width: 100%;
-}
-
 .inventory-item .inventory-file-image span.current-file {
   margin: 6px -12px 6px 12px;
 }

--- a/guests/templates/guests_common.html
+++ b/guests/templates/guests_common.html
@@ -97,6 +97,11 @@
   width: 100%;
 }
 
+.inventory-item .inventory-file-image img {
+  display: block;
+  width: 100%;
+}
+
 .inventory-item .inventory-file-image span.current-file {
   margin: 6px -12px 6px 12px;
 }
@@ -139,9 +144,23 @@ h3 .inventory-add-item {
   padding-bottom: 0;
 }
 
-.inventory-table img {
+.inventory-table .image-preview > img {
   width: 200px;
   max-width: 100%;
+}
+
+.inventory-table .image-preview > div {
+  max-width: 100%;
+  display: inline-block;
+  background-color: #f8f8ff;
+  border: 1px solid #428bca;
+  padding: 25px 10px;
+  text-align: center;
+}
+
+.inventory-table .image-preview > div:hover {
+  background-color: #f0f0f8;
+  border-color: #2a6496;
 }
 
 .inventory-table dt {

--- a/guests/templates/guests_macros.html
+++ b/guests/templates/guests_macros.html
@@ -1,19 +1,29 @@
 {% import 'macros.html' as macros %}
 
-{% macro inventory_image(item=None, name='image', class='') -%}
+{% macro inventory_image(item=None, name='image', class='', suppress_preview=False) -%}
   {%- set inventory_url = guest_merch.inventory_url(item.id, name) -%}
-  <a href="{{ inventory_url }}" target="_blank"><img src="{{ inventory_url }}" class="{{ class }}"/></a>
+  <a href="{{ inventory_url }}" target="_blank" class="preview image-preview {{ class }}">
+    {%- if suppress_preview -%}
+      <div><span class="glyphicon glyphicon-picture"></span> View image</div>
+    {%- else -%}
+      <img src="{{ inventory_url }}"/>
+    {%- endif -%}
+  </a>
 {%- endmacro %}
 
 
-{% macro inventory_audio(item=None, name='audio', class='') -%}
+{% macro inventory_audio(item=None, name='audio', class='', suppress_preview=False) -%}
   {%- set inventory_url = guest_merch.inventory_url(item.id, name) -%}
   {% set content_type_attr = name ~ '_content_type' %}
   {% set download_filename_attr = name ~ '_download_filename' %}
-  <audio controls class="{{ class }}" title="{{ item[download_filename_attr] }}" preload="none">
-    <source src="{{ inventory_url }}" type="{{ item[content_type_attr] }}">
-    <a href="{{ inventory_url }}">Click to download audio file</a>
-  </audio>
+  {%- if suppress_preview -%}
+    <a href="{{ inventory_url }}" class="preview audio-preview {{ class }}"><div>Download audio file</div></a>
+  {%- else -%}
+    <audio controls class="preview audio-preview {{ class }}" title="{{ item[download_filename_attr] }}" preload="none">
+      <source src="{{ inventory_url }}" type="{{ item[content_type_attr] }}">
+      <a href="{{ inventory_url }}">Click to download audio file</a>
+    </audio>
+  {%- endif -%}
 {%- endmacro %}
 
 
@@ -238,7 +248,7 @@
 {%- endmacro %}
 
 
-{% macro inventory_table_row(item, show_controls=False) -%}
+{% macro inventory_table_row(item, show_controls=False, suppress_preview=False) -%}
   {%- set type = item.type|int -%}
   {%- set quantity = guest_merch.total_quantity(item) if type in [c.TSHIRT, c.APPAREL] else item.quantity -%}
   <tr id="inventory_row_{{ item.id }}" class="inventory-row" data-item_id="{{ item.id }}">
@@ -265,7 +275,7 @@
     {%- else -%}
       <td class="inventory-item-custom"></td>
     {%- endif %}
-    <td class="inventory-item-image">{{ inventory_image(item, class='') }}</td>
+    <td class="inventory-item-image">{{ inventory_image(item, class='', suppress_preview=suppress_preview) }}</td>
     {%- if show_controls -%}
       <td class="inventory-item-controls">
         <div class="btn-group-vertical" role="group">
@@ -282,7 +292,7 @@
 {%- endmacro %}
 
 
-{% macro inventory_table(show_controls=False) -%}
+{% macro inventory_table(show_controls=False, suppress_preview=False) -%}
   <div class="table-responsive">
     <table
         class="table table-hover datatable inventory-table"
@@ -300,16 +310,14 @@
           <th class="inventory-item-custom" data-orderable="false"></th>
           <th class="inventory-item-image" data-orderable="false"></th>
           {%- if show_controls -%}
-            <th class="inventory-item-controls" data-orderable="false">
-              &#9679;&#9679;&#9679;
-            </th>
+            <th class="inventory-item-controls" data-orderable="false"></th>
           {%- endif -%}
         </tr>
       </thead>
       <tbody>
         {% if guest_merch.inventory -%}
           {% for item in guest_merch.inventory.values() -%}
-            {{ inventory_table_row(item, show_controls=show_controls) }}
+            {{ inventory_table_row(item, show_controls=show_controls, suppress_preview=suppress_preview) }}
           {%- endfor %}
         {%- endif %}
       </tbody>
@@ -318,12 +326,12 @@
 {%- endmacro %}
 
 
-{% macro inventory_table_with_err(err_class='') -%}
+{% macro inventory_table_with_err(err_class='', suppress_preview=False) -%}
   {%- if guest_merch.selling_merch != c.ROCK_ISLAND -%}
     <div class="text-danger text-center {{ err_class }}">This group is not using Rock Island services.</div>
   {%- elif not guest_merch.inventory -%}
     <div class="text-danger text-center {{ err_class }}">This group has not uploaded any inventory.</div>
   {%- else -%}
-    {{ inventory_table() }}
+    {{ inventory_table(suppress_preview=suppress_preview) }}
   {%- endif -%}
 {%- endmacro %}


### PR DESCRIPTION
The little image previews in the Rock Island table actually use the full resolution image for the `src`. That's not ideal, but it's okay if you only have a few images on the screen at a given time.

I realized that the full /guest_admin/rock_island page will end up displaying every promo image at the full resolution. Huge bandwidth/performance hog.

The *correct* solution would be to implement true image thumbnails. That could be a significant development task, so instead I opted to suppress the image previews on the full rock_island page.

Looks like this now:
<img width="894" alt="screen shot 2017-10-04 at 7 52 45 pm" src="https://user-images.githubusercontent.com/2592431/31205254-54e6fe22-a93e-11e7-9de3-b7eaaf34703d.png">
