### PR TITLE
Removes empty inventory validation check

### DIFF
--- a/guests/model_checks.py
+++ b/guests/model_checks.py
@@ -7,10 +7,7 @@ def is_merch_checklist_complete(guest_merch):
         return 'You need to tell us whether and how you want to sell merchandise'
 
     elif guest_merch.selling_merch == c.ROCK_ISLAND:
-        if not guest_merch.inventory:
-            return 'You must add some merch to your inventory!'
-
-        elif not guest_merch.poc_is_group_leader and not (
+        if not guest_merch.poc_is_group_leader and not (
                 guest_merch.poc_first_name and
                 guest_merch.poc_last_name and
                 guest_merch.poc_phone and


### PR DESCRIPTION
I think it would be better if a band could choose to use Rock Island services without immediately knowing what merch they're selling. By removing the empty inventory validation check, a band can choose Rock Island, and then come back later to update their inventory.