### PR TITLE
Reverts GuestMerch.status to not use models_checks.py

### DIFF
--- a/guests/models.py
+++ b/guests/models.py
@@ -304,8 +304,6 @@ class GuestMerch(MagModel):
 
     @property
     def status(self):
-        if check(self):
-            return None
         return self.selling_merch_label
 
     @presave_adjustment


### PR DESCRIPTION
Since we no longer consider an empty inventory an invalid state, the model check inside of `status()` is no longer needed. Plus, returning `None` from `status()` was breaking our guests table:

<img width="1080" alt="screen shot 2017-10-05 at 4 43 15 pm" src="https://user-images.githubusercontent.com/2592431/31251613-8ad89c26-a9ec-11e7-80c1-a8829f140ce1.png">
